### PR TITLE
Update TextureVideoView.java

### DIFF
--- a/library/src/com/dd/crop/TextureVideoView.java
+++ b/library/src/com/dd/crop/TextureVideoView.java
@@ -98,7 +98,7 @@ public class TextureVideoView extends TextureView implements TextureView.Surface
         float scaleX = 1.0f;
         float scaleY = 1.0f;
 
-        if (mVideoWidth > viewWidth && mVideoHeight > viewHeight) {
+        if (mVideoWidth >= viewWidth && mVideoHeight >= viewHeight) {
             scaleX = mVideoWidth / viewWidth;
             scaleY = mVideoHeight / viewHeight;
         } else if (mVideoWidth < viewWidth && mVideoHeight < viewHeight) {


### PR DESCRIPTION
It should be >= otherwise when the video match one side it stretches it
